### PR TITLE
API: break `get` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ Out[5]: 'foo'
 
 ```
 
-via `put` and `get`
+via `put` and `past`
 
 ```python
 In [6]: hist.put('k', 'bar')
 
-In [7]: hist.get('k')
+In [7]: hist.past('k')
 Out[7]: 'bar'
 
 ```
 
-Using `get` you can extract past values
+Using `past` you can extract past values
 
 ```python
 In [8]: hist['key'] = 'baz'
@@ -48,17 +48,18 @@ In [11]:
 In [11]: hist['key']
 Out[11]: 'aardvark'
 
-In [12]: hist.get('key', 1)
+In [12]: hist.past('key', 1)
 Out[12]: 'buz'
 
-In [13]: hist.get('key', 2)
+In [13]: hist.past('key', 2)
 Out[13]: 'baz'
 
-In [14]: hist.get('key', 3)
+In [14]: hist.past('key', 3)
 Out[14]: 'foo'
 
 ```
 
+All `MutableMapping` methods except `del` and `pop` work.
 
 
 ## Known limitation
@@ -76,3 +77,6 @@ string representations.
 
 The values are stored via a json blob, thus only values which can be
 converted to json can be stored (no numpy arrays currently).
+
+`h.del` and `h.pop` do not work (yet).  Just need to write the
+sql query to delete them.

--- a/history.py
+++ b/history.py
@@ -68,7 +68,7 @@ class History(MutableMapping):
 
     def __getitem__(self, key):
         if key == self.RESERVED_KEY_KEY:
-            raise ValueError("can not.past internal keys through []")
+            raise ValueError("can not get internal keys through []")
         return self._cache[key]
 
     def __setitem__(self, key, val):
@@ -98,7 +98,7 @@ class History(MutableMapping):
         Retrieve a past state of the data payload associated with `key`,
         by default the most recent state.  Previous states can be accessed
         via the `num_back` kwarg which will retrieve the nth back entry (so
-        `num_back=0` get the latest, `num_back=5`.pasts the fifth most recent.
+        `num_back=0` get the latest, `num_back=5` gets the fifth most recent.
 
         Parameters
         ----------

--- a/history.py
+++ b/history.py
@@ -62,13 +62,13 @@ class History(MutableMapping):
             self._create_tables()
         else:
             logger.debug("Found an existing table in %s", fname)
-        self._keys = self.get(self.RESERVED_KEY_KEY)
+        self._keys = self.past(self.RESERVED_KEY_KEY)
         for k in self._keys:
-            self._cache[k] = self.get(k)
+            self._cache[k] = self.past(k)
 
     def __getitem__(self, key):
         if key == self.RESERVED_KEY_KEY:
-            raise ValueError("can not get internal keys through []")
+            raise ValueError("can not.past internal keys through []")
         return self._cache[key]
 
     def __setitem__(self, key, val):
@@ -93,12 +93,12 @@ class History(MutableMapping):
     def __len__(self):
         return len(self._cache)
 
-    def get(self, key, num_back=0):
+    def past(self, key, num_back=0):
         """
         Retrieve a past state of the data payload associated with `key`,
         by default the most recent state.  Previous states can be accessed
         via the `num_back` kwarg which will retrieve the nth back entry (so
-        `num_back=0` get the latest, `num_back=5` gets the fifth most recent.
+        `num_back=0` get the latest, `num_back=5`.pasts the fifth most recent.
 
         Parameters
         ----------

--- a/test_history.py
+++ b/test_history.py
@@ -14,26 +14,26 @@ def setup():
 
 def test_history():
     run_id = ''.join(['a'] * OBJ_ID_LEN)
-    # Simple round-trip: put and get
+    # Simple round-trip: put and past
     config1 = {'plot_x': 'long', 'plot_y': 'island'}
     h.put(run_id, config1)
-    result1 = h.get(run_id)
+    result1 = h.past(run_id)
     assert_equal(result1, config1)
 
-    # Put a second entry. Check that get returns most recent.
+    # Put a second entry. Check that past returns most recent.
     config2 = {'plot_x': 'new', 'plot_y': 'york'}
     h.put(run_id, config2)
-    result2 = h.get(run_id)
+    result2 = h.past(run_id)
     assert_equal(result2, config2)
-    # And get(..., 1) returns previous.
-    result1 = h.get(run_id, 1)
+    # And.past(..., 1) returns previous.
+    result1 = h.past(run_id, 1)
     assert_equal(result1, config1)
 
 
 def test_clear():
     h.put('hi', 'mom')
     h.clear()
-    assert_raises(KeyError, lambda: h.get('hi'))
+    assert_raises(KeyError, lambda: h.past('hi'))
 
 
 def test_trim():
@@ -41,7 +41,7 @@ def test_trim():
 
 
 def test_neg_numback_fails():
-    assert_raises(ValueError, h.get, 'test', -1)
+    assert_raises(ValueError, h.past, 'test', -1)
 
 
 def test_gs_items():
@@ -89,3 +89,9 @@ def test_len():
         h[k] = k
 
     assert_equal(len(keys), len(h))
+
+
+def test_get():
+    h.clear()
+    b = h.get('b', 'aardvark')
+    assert_equal(b, 'aardvark')


### PR DESCRIPTION
We were shadowing MutableMapping.get with our history-aware get.

history aware get has been remaned to `past`, `get` now is
the MutableMapping `get` and behaves as expected.
