### PR TITLE
API: version bump the table version

### DIFF
--- a/history.py
+++ b/history.py
@@ -17,7 +17,7 @@ from collections import MutableMapping
 logger = logging.getLogger(__name__)
 
 
-TABLE_NAME = 'HISTORY_1_0'
+TABLE_NAME = 'HISTORY_1_1'
 CREATION_QUERY = """
 CREATE TABLE {0} (
         _id CHAR(40),


### PR DESCRIPTION
There may be existing files which do not have the list of keys in them
which will raise errors on init as the list of keys will not be found in
the database.
